### PR TITLE
Add Document Provenance Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 http://build.fhir.org/ig/IHE/QEDm/branches/master/index.html
 
 
+
 ## QEDm
 FHIR Constraints for QEDm
 

--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -2,3 +2,5 @@ Alias: SCT = http://snomed.info/sct
 Alias: UCUM = http://unitsofmeasure.org
 Alias: LOINC = http://loinc.org
 
+Alias: $w3c-provenance-activity-type = http://hl7.org/fhir/w3c-provenance-activity-type
+Alias: $provenance-participant-type = http://terminology.hl7.org/CodeSystem/provenance-participant-type

--- a/input/fsh/ex-provenance.fsh
+++ b/input/fsh/ex-provenance.fsh
@@ -10,8 +10,6 @@ Usage: #example
 * content.attachment.title = "Hello World"
 * content.attachment.contentType = #text/plain
 
-
-
 Instance:   ex-device
 InstanceOf: Device
 Title:      "Dummy Device example"
@@ -41,3 +39,19 @@ Usage: #example
 * entity[0].role = #source
 * entity[0].what = Reference(ex-documentreference)
 
+Instance: IHE-QEDm-Provenance-Example
+InstanceOf: IHE_QEDm_Provenance
+Description: "Provenance example for use in QEDm when the data-elements (Resources pointed to by target) come from an XDS or MHD document"
+Usage: #example
+* target[+] = Reference(ex-encounter)
+* occurredDateTime = "2023-08-15T20:16:40+02:00"
+* recorded = "2023-09-26T17:20:59.765+02:00"
+* policy = "urn:ihe:pcc:qedm:2017:document-provenance-policy"
+* agent[0].type = $provenance-participant-type#assembler "Assembler"
+* agent[=].who = Reference(ex-device)
+* entity.role = #source
+* entity.what = Reference(http://example.org/fhir/DocumentReference/urn:oid:1.2.3.99.2) "CDA Document in XDS Repository"
+* entity.what.type = "DocumentReference"
+* entity.what.identifier.use = #official
+* entity.what.identifier.system = "urn:oid:1.2.3.999"
+* entity.what.identifier.value = "urn:oid:1.2.3.999.2"

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -1,0 +1,38 @@
+Profile: IHE_QEDm_Provenance
+Parent: Provenance
+Id: IHE.QEDm.Provenance
+Title: "QEDm Provenance"
+Description: "Provenance profile for use in QEDm when the data-elements (Resources pointed to by target) come from an XDS or MHD document. See [Profile Description](http://wiki.ihe.net/index.php/Query_for_Existing_Data_for_Mobile)"
+* ^url = "https://profiles.ihe.net/PCC/QEDm/StructureDefinition/IHE.QEDm.Provenance"
+* ^status = #draft
+* ^date = "2019-07-09"
+* ^publisher = "Integrating the Healthcare Enterprise (IHE)"
+* ^contact[0].name = "IHE"
+* ^contact[=].telecom.system = #url
+* ^contact[=].telecom.value = "http://ihe.net"
+* ^contact[+].name = "John Moehrke"
+* ^contact[=].telecom.system = #email
+* ^contact[=].telecom.value = "JohnMoehrke@gmail.com"
+* ^copyright = "IHE [Intellectual Property rules/rights](http://www.ihe.net/Governance/#Intellectual_Property)"
+* . 1..1
+* policy 1..1
+* policy = "urn:ihe:pcc:qedm:2017:document-provenance-policy" (exactly)
+* activity 1..
+* activity ^code = $w3c-provenance-activity-type#Derivation
+* agent ^label = "assembler"
+* agent ^slicing.discriminator.type = #pattern
+* agent ^slicing.discriminator.path = "type"
+* agent ^slicing.description = "Assembler of the FHIR Resources"
+* agent ^slicing.rules = #open
+* agent contains theAssembler 1..1
+* agent[theAssembler].type 1..
+* agent[theAssembler].type = $provenance-participant-type#assembler
+* agent[theAssembler].who only Reference(Device)
+* agent[theAssembler].who ^short = "Service identity"
+* agent[theAssembler].who ^definition = "Device Resource identifying the extraction device. This should be by reference to a known Device Resource by may be a contained resource or an identifier."
+* agent[theAssembler].who ^type.aggregation[0] = #contained
+* agent[theAssembler].who ^type.aggregation[+] = #referenced
+* agent[theAssembler].who.reference 1..
+* entity 1..1
+* entity.role = #source (exactly)
+* entity.agent ..0

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -17,8 +17,6 @@ Description: "Provenance profile for use in QEDm when the data-elements (Resourc
 * . 1..1
 * policy 1..1
 * policy = "urn:ihe:pcc:qedm:2017:document-provenance-policy" (exactly)
-* activity 1..
-* activity ^code = $w3c-provenance-activity-type#Derivation
 * agent ^label = "assembler"
 * agent ^slicing.discriminator.type = #pattern
 * agent ^slicing.discriminator.path = "type"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -30,34 +30,26 @@ copyrightYear: 2023+
 dependencies:
   ihe.iti.mhd: 
     id: iheitimhd
-    uri: https://profiles.ihe.net/ITI/MHD/ImplementationGuide/ihe.iti.mhd
     version: 4.2.1 
   ihe.iti.pdqm: 
     id: ihepdqm
-    uri: https://profiles.ihe.net/ITI/PDQm/ImplementationGuide/ihe.iti.pdqm
     version: 2.4.0
   ihe.iti.pixm:
     id: iheitipixm
-    uri: https://profiles.ihe.net/ITI/PIXm/ImplementationGuide/ihe.iti.pixm
     version: 3.0.3
   ihe.iti.mcsd:
     id: iheitimcsd
-    uri: https://profiles.ihe.net/ITI/mCSD/ImplementationGuide/ihe.iti.mcsd
     version: 3.8.0
   ihe.formatcode.fhir:
     id: iheformatcodefhir
-    uri: https://profiles.ihe.net/fhir/ihe.formatcode.fhir/ImplementationGuide/ihe.formatcode.fhir
     version: 1.1.0
   ihe.iti.balp:
     id: iheitibasicaudit
-    uri: https://profiles.ihe.net/ITI/BALP/ImplementationGuide/ihe.iti.balp
     version: 1.1.2
   ihe.iti.svcm:
     id: iheitisvcm
-    uri: https://profiles.ihe.net/ITI/SVCM/ImplementationGuide/ihe.iti.svcm
     version: 1.5.1
   ihe.iti.mxde:
-    id: iheitimxde
     uri: https://profiles.ihe.net/ITI/mXDE/ImplementationGuide/ihe.iti.mxde
     version: 1.3.0
 # TODO likely other dependencies

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -31,42 +31,35 @@ dependencies:
   ihe.iti.mhd: 
     id: iheitimhd
     uri: https://profiles.ihe.net/ITI/MHD/ImplementationGuide/ihe.iti.mhd
-    version: current
-#    version: 4.2.0
+    version: 4.2.1 
   ihe.iti.pdqm: 
     id: ihepdqm
     uri: https://profiles.ihe.net/ITI/PDQm/ImplementationGuide/ihe.iti.pdqm
-    version: current
-#    version: 2.4.0
+    version: 2.4.0
   ihe.iti.pixm:
     id: iheitipixm
     uri: https://profiles.ihe.net/ITI/PIXm/ImplementationGuide/ihe.iti.pixm
-    version: current
-#    version: 3.0.2
+    version: 3.0.3
   ihe.iti.mcsd:
     id: iheitimcsd
     uri: https://profiles.ihe.net/ITI/mCSD/ImplementationGuide/ihe.iti.mcsd
-    version: current
-#    version: 3.8.0
+    version: 3.8.0
   ihe.formatcode.fhir:
     id: iheformatcodefhir
     uri: https://profiles.ihe.net/fhir/ihe.formatcode.fhir/ImplementationGuide/ihe.formatcode.fhir
-    version: current
-#    version: 1.1.0
+    version: 1.1.0
   ihe.iti.balp:
     id: iheitibasicaudit
     uri: https://profiles.ihe.net/ITI/BALP/ImplementationGuide/ihe.iti.balp
-    version: current
-#    version: 1.1.1
+    version: 1.1.2
   ihe.iti.svcm:
     id: iheitisvcm
     uri: https://profiles.ihe.net/ITI/SVCM/ImplementationGuide/ihe.iti.svcm
-    version: current
-#    version: 1.5.0
+    version: 1.5.1
   ihe.iti.mxde:
     id: iheitimxde
     uri: https://profiles.ihe.net/ITI/mXDE/ImplementationGuide/ihe.iti.mxde
-    version: current
+    version: 1.3.0
 # TODO likely other dependencies
 
 parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters


### PR DESCRIPTION
IHE_PCC_Suppl_QEDm.pdf

This PR is a left over of the last connectathon. I noticed that  the 3.44.4.2.2.1 Document Provenance Option is not defined as a profile in the IG (it existed in the IHE implemementation materials).

This PR adds the profile and example for it, it is complete, however there are new errors appearing in the qa section about vital signs profiles. see link in ci-build.

https://build.fhir.org/ig/oliveregger/QEDm/branches/oe_provenance/qa.html

This PR updates also the IG's to the latest versions.